### PR TITLE
feat: add error handling as described in #3

### DIFF
--- a/packages/discovery/src/client.ts
+++ b/packages/discovery/src/client.ts
@@ -40,7 +40,7 @@ export class DiscoveryClient {
         'Accept': this.rdf.contentType
       }
     })
-    if (response.status <200 || response.status >300){
+    if (response.status < 200 || response.status > 300) {
       throw Error(`Failed fetching resource: ${resourceUri}`)
     }
     return this.rdf.parse(await response.text(), response.url)
@@ -48,7 +48,7 @@ export class DiscoveryClient {
 
   async discoverStorageDescription(resourceUri: string): Promise<string> {
     const response = await this.authnFetch(resourceUri, { method: 'head' })
-    if (response.status <200 || response.status >300){
+    if (response.status < 200 || response.status > 300) {
       throw Error(`Failed fetching resource: ${resourceUri}`)
     }
     return getStorageDescription(response.headers.get('Link'))

--- a/packages/discovery/src/client.ts
+++ b/packages/discovery/src/client.ts
@@ -40,11 +40,17 @@ export class DiscoveryClient {
         'Accept': this.rdf.contentType
       }
     })
+    if (response.status <200 || response.status >300){
+      throw Error(`Failed fetching resource: ${resourceUri}`)
+    }
     return this.rdf.parse(await response.text(), response.url)
   }
 
   async discoverStorageDescription(resourceUri: string): Promise<string> {
     const response = await this.authnFetch(resourceUri, { method: 'head' })
+    if (response.status <200 || response.status >300){
+      throw Error(`Failed fetching resource: ${resourceUri}`)
+    }
     return getStorageDescription(response.headers.get('Link'))
   }
 

--- a/packages/discovery/test/client.test.ts
+++ b/packages/discovery/test/client.test.ts
@@ -57,4 +57,10 @@ describe("discovery", () => {
     const service = await client.findService(cardUri, 'https://fake.example/SomeChannel')
     expect(service).toBeNull()
   });
+
+  test("error on non-exisiting resource", async () => {
+    const client = new DiscoveryClient(stu.authFetch)
+
+    await expect(() =>client.findService("http://localhost:3001/non-existing-container/", NOTIFY.WebSocketChannel2023.value)).rejects.toThrowError()
+  })
 });

--- a/packages/subscription/src/client.ts
+++ b/packages/subscription/src/client.ts
@@ -53,6 +53,11 @@ export class SubscriptionClient {
   async subscribe(topic: string, channelType: ChannelType, sendTo?: string): Promise<NotificationChannel> {
     // TODO: validate presence of sendTo based on known channel type
     const service = await this.discovery.findService(topic, channelType)
+
+    if (!service) {
+      throw Error(`Discovery did not succeed: channel type ${channelType} is not supported by the Solid Server.`)
+    }
+
     const requestedChannel = buildChannel(topic, channelType, sendTo)
     const response = await this.authnFetch(service.id, {
       method: 'POST',

--- a/packages/subscription/test/client.test.ts
+++ b/packages/subscription/test/client.test.ts
@@ -30,4 +30,8 @@ describe("subscription", () => {
     }))
   });
 
+  test("subscribe for non supported channel type",async () => {
+    const client = new SubscriptionClient(stu.authFetch)
+    await expect(() => client.subscribe(cardUri, NOTIFY.LDNChannel2023.value)).rejects.toThrowError()
+  })
 });


### PR DESCRIPTION
Adds a more readable error for https://github.com/o-development/solid-notification-client/issues/3#issuecomment-1698799015

Additionally, I've added some error handling when the topic resource can not be requested (otherwise you get `TypeError: Cannot read properties of null (reading 'replace')`, where it is not very clear what went wrong).
